### PR TITLE
Created basic bitboard header file

### DIFF
--- a/bitboard.h
+++ b/bitboard.h
@@ -1,0 +1,87 @@
+#ifndef BITBOARD_H
+#define BITBOARD_H
+
+#include <cstdint>
+#include <string>
+using namespace std;
+
+// Ranks
+constexpr bitboard RANK_1 = 0x00000000000000FF;
+constexpr bitboard RANK_2 = 0x000000000000FF00;
+constexpr bitboard RANK_3 = 0x0000000000FF0000;
+constexpr bitboard RANK_4 = 0x00000000FF000000;
+constexpr bitboard RANK_5 = 0x000000FF00000000;
+constexpr bitboard RANK_6 = 0x0000FF0000000000;
+constexpr bitboard RANK_7 = 0x00FF000000000000;
+constexpr bitboard RANK_8 = 0xFF00000000000000;
+
+// Files
+constexpr bitboard FILE_A = 0x0101010101010101;
+constexpr bitboard FILE_B = 0x0202020202020202;
+constexpr bitboard FILE_C = 0x0404040404040404;
+constexpr bitboard FILE_D = 0x0808080808080808;
+constexpr bitboard FILE_E = 0x1010101010101010;
+constexpr bitboard FILE_F = 0x2020202020202020;
+constexpr bitboard FILE_G = 0x4040404040404040;
+constexpr bitboard FILE_H = 0x8080808080808080;
+
+namespace boardUtils{
+	using bitboard = uint64_t; // type alias
+
+	bitboard setBit(bitboard b, int square){
+		return b | 1ULL << square;
+	}
+
+	bitboard clearBit(bitboard b, int square){
+		return b & ~(1ULL << square);
+	}
+
+	bitboard toggleBit(bitboard b, int square){
+		return b ^ (1ULL << square);
+	}
+
+	bool isBitSet(bitboard b, int square){
+		return (b & (1ULL << square)) != 0;
+	}
+
+	bitboard resetBoard(bitboard b){
+		return 0ULL;
+	}
+
+	// shift operations
+	bitboard north(bitboard b) {
+        return (b << 8) & ~FILE_A;  // Shift up, and mask A-file to prevent wrapping
+    }
+
+    bitboard south(bitboard b) {
+        return (b >> 8) & ~FILE_A;  // Shift down, and mask A-file to prevent wrapping
+    }
+
+    bitboard east(bitboard b) {
+        return (b << 1) & ~FILE_H;  // Shift right, and mask H-file to prevent wrapping
+    }
+
+    bitboard west(bitboard b) {
+        return (b >> 1) & ~FILE_A;  // Shift left, and mask A-file to prevent wrapping
+    }
+
+	bitboard northEast(bitboard b) {
+	    return (b << 9) & ~(FILE_A);  // Shift diagonally up-right, and mask A-file to prevent wrapping
+	}
+
+	bitboard northWest(bitboard b) {
+	    return (b << 7) & ~(FILE_H);  // Shift diagonally up-left, and mask H-file to prevent wrapping
+	}
+
+	bitboard southEast(bitboard b) {
+	    return (b >> 7) & ~(FILE_A);  // Shift diagonally down-right, and mask A-file to prevent wrapping
+	}
+
+	bitboard southWest(bitboard b) {
+	    return (b >> 9) & ~(FILE_H);  // Shift diagonally down-left, and mask H-file to prevent wrapping
+	}
+
+}
+
+
+


### PR DESCRIPTION
boardUtils Functions Documentation
setBit(bitboard b, int square)
Sets the bit at a specific square on the bitboard. Parameters: b (current bitboard), square (the square to set) Returns: Updated bitboard with the bit at the specified square set.

clearBit(bitboard b, int square)
Clears the bit at a specific square on the bitboard. Parameters: b (current bitboard), square (the square to clear) Returns: Updated bitboard with the bit at the specified square cleared.

toggleBit(bitboard b, int square)
Toggles the bit at a specific square on the bitboard (sets it if it's cleared, clears it if it's set). Parameters: b (current bitboard), square (the square to toggle) Returns: Updated bitboard with the bit at the specified square toggled.

isBitSet(bitboard b, int square)
Checks if a bit at a specific square is set (i.e., if the square is occupied). Parameters: b (current bitboard), square (the square to check) Returns: true if the bit is set, otherwise false.

resetBoard(bitboard b)
Resets the bitboard, clearing all bits.
Parameters: b (current bitboard)
Returns: 0ULL (reset bitboard).

Shift Operations
north(bitboard b)
Shifts the bitboard up (north) by one rank and masks out the A-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted up by one rank.

south(bitboard b)
Shifts the bitboard down (south) by one rank and masks out the A-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted down by one rank.

east(bitboard b)
Shifts the bitboard right (east) by one file and masks out the H-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted right by one file.

west(bitboard b)
Shifts the bitboard left (west) by one file and masks out the A-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted left by one file.

Diagonal Shift Operations
northEast(bitboard b)
Shifts the bitboard diagonally up-right (north-east) and masks out the A-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted diagonally up-right.

northWest(bitboard b)
Shifts the bitboard diagonally up-left (north-west) and masks out the H-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted diagonally up-left.

southEast(bitboard b)
Shifts the bitboard diagonally down-right (south-east) and masks out the A-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted diagonally down-right.

southWest(bitboard b)
Shifts the bitboard diagonally down-left (south-west) and masks out the H-file to prevent wrapping. Parameters: b (current bitboard)
Returns: Bitboard shifted diagonally down-left.